### PR TITLE
Add start script for Vite

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "start": "vite",
     "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"
   },


### PR DESCRIPTION
- Added a start script to the package.json file to enable running the command npm start in the /frontend directory.
- Could previously only run the frontend through the command npm run dev.
- This allows for easier startup of the application using Vite.
